### PR TITLE
Fixed NullPointerException when skipping execution

### DIFF
--- a/engine/src/main/java/org/verifyica/engine/descriptor/ArgumentTestDescriptor.java
+++ b/engine/src/main/java/org/verifyica/engine/descriptor/ArgumentTestDescriptor.java
@@ -276,6 +276,12 @@ public class ArgumentTestDescriptor extends TestableTestDescriptor {
 
         while (testableTestDescriptorIterator.hasNext()) {
             TestableTestDescriptor testableTestDescriptor = testableTestDescriptorIterator.next();
+
+            Injector.inject(ENGINE_EXECUTION_LISTENER, engineExecutionListener, testableTestDescriptor);
+            Injector.inject(CLASS_INTERCEPTORS, classInterceptors, testableTestDescriptor);
+            Injector.inject(CLASS_INTERCEPTORS_REVERSED, classInterceptorsReversed, testableTestDescriptor);
+            Injector.inject(ARGUMENT_CONTEXT, argumentContext, testableTestDescriptor);
+
             testableTestDescriptor.skip();
         }
 

--- a/engine/src/main/java/org/verifyica/engine/descriptor/ClassTestDescriptor.java
+++ b/engine/src/main/java/org/verifyica/engine/descriptor/ClassTestDescriptor.java
@@ -109,6 +109,7 @@ public class ClassTestDescriptor extends TestableTestDescriptor {
      *
      * @param uniqueId uniqueId
      * @param displayName displayName
+     * @param tags tags
      * @param testClass testClass
      * @param testArgumentParallelism testArgumentParallelism
      * @param prepareMethods prepareMethods

--- a/engine/src/main/java/org/verifyica/engine/descriptor/TestableTestDescriptor.java
+++ b/engine/src/main/java/org/verifyica/engine/descriptor/TestableTestDescriptor.java
@@ -70,7 +70,7 @@ public abstract class TestableTestDescriptor extends AbstractTestDescriptor {
             testDescriptor -> (TestableTestDescriptor) testDescriptor;
 
     @Inject
-    @Named("EngineExecutionListener")
+    @Named(ENGINE_EXECUTION_LISTENER)
     private EngineExecutionListener engineExecutionListener;
 
     private TestDescriptorStatus testDescriptorStatus;

--- a/tests/src/test/java/org/verifyica/test/inheritance/AbstractAutowiredTest.java
+++ b/tests/src/test/java/org/verifyica/test/inheritance/AbstractAutowiredTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The Verifyica project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.verifyica.test.inheritance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.verifyica.api.Configuration;
+import org.verifyica.api.EngineContext;
+import org.verifyica.api.Verifyica;
+
+public abstract class AbstractAutowiredTest {
+
+    @Verifyica.Autowired
+    private EngineContext engineContext;
+
+    @Verifyica.Autowired
+    private Configuration configuration;
+
+    @Verifyica.Test
+    public void test1(String argument) {
+        assertThat(engineContext).isNotNull();
+        assertThat(configuration).isNotNull();
+        assertThat(argument).isNotNull();
+    }
+}

--- a/tests/src/test/java/org/verifyica/test/inheritance/ConcreteAutowiredTest.java
+++ b/tests/src/test/java/org/verifyica/test/inheritance/ConcreteAutowiredTest.java
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-package org.verifyica.test;
+package org.verifyica.test.inheritance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.verifyica.test.support.AssertionSupport.assertArgumentContext;
-import static org.verifyica.test.support.TestSupport.logArgumentContext;
 
-import org.verifyica.api.ArgumentContext;
 import org.verifyica.api.Configuration;
 import org.verifyica.api.EngineContext;
 import org.verifyica.api.Verifyica;
 
-public class AutowiredTest {
+public class ConcreteAutowiredTest extends AbstractAutowiredTest {
 
     @Verifyica.Autowired
     private EngineContext engineContext;
@@ -39,34 +36,9 @@ public class AutowiredTest {
     }
 
     @Verifyica.Test
-    public void test(ArgumentContext argumentContext) throws Throwable {
-        logArgumentContext("test()", argumentContext);
-
-        assertArgumentContext(argumentContext);
+    public void test2(String argument) {
         assertThat(engineContext).isNotNull();
         assertThat(configuration).isNotNull();
-    }
-
-    public static class NestedAutowiredTest {
-
-        @Verifyica.Autowired
-        private EngineContext engineContext;
-
-        @Verifyica.Autowired
-        private Configuration configuration;
-
-        @Verifyica.ArgumentSupplier
-        public static Object arguments() {
-            return "test";
-        }
-
-        @Verifyica.Test
-        public void test(ArgumentContext argumentContext) throws Throwable {
-            logArgumentContext("test()", argumentContext);
-
-            assertArgumentContext(argumentContext);
-            assertThat(engineContext).isNotNull();
-            assertThat(configuration).isNotNull();
-        }
+        assertThat(argument).isNotNull();
     }
 }


### PR DESCRIPTION
Fixed `NullPointerException` when skipping execution

```
java.lang.NullPointerException: Cannot invoke "org.junit.platform.engine.EngineExecutionListener.executionStarted(org.junit.platform.engine.TestDescriptor)" because "this.engineExecutionListener" is null
	at org.verifyica.engine.descriptor.TestableTestDescriptor.skip(TestableTestDescriptor.java:104)
	at org.verifyica.engine.descriptor.ArgumentTestDescriptor.doTestDependent(ArgumentTestDescriptor.java:285)
	at org.verifyica.engine.descriptor.ArgumentTestDescriptor.test(ArgumentTestDescriptor.java:146)
	at org.verifyica.engine.descriptor.ArgumentTestDescriptor.test(ArgumentTestDescriptor.java:44)
	at io.github.thunkware.vt.bridge.ThreadNameRunnable.run(ThreadNameRunnable.java:39)
	at org.verifyica.engine.common.SemaphoreRunnable.run(SemaphoreRunnable.java:46)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at org.verifyica.engine.common.DirectExecutorService.execute(DirectExecutorService.java:65)
	at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:123)
	at org.verifyica.engine.descriptor.ClassTestDescriptor.doTest(ClassTestDescriptor.java:357)
	at org.verifyica.engine.descriptor.ClassTestDescriptor.test(ClassTestDescriptor.java:193)
	at org.verifyica.engine.descriptor.ClassTestDescriptor.test(ClassTestDescriptor.java:58)
	at io.github.thunkware.vt.bridge.ThreadNameRunnable.run(ThreadNameRunnable.java:39)
	at io.github.thunkware.vt.bridge.SemaphoreExecutor.lambda$toSemaphoreRunnable$2(SemaphoreExecutor.java:61)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309)
