### PR TITLE
Fix ordering semantics

### DIFF
--- a/ANNOTATIONS.md
+++ b/ANNOTATIONS.md
@@ -213,7 +213,7 @@ All methods annotated with `@Verifyica.Test`:
 
 - Default ordering is by test method name (or `@verifyica.DisplayName` if used)
 
-- test methods without an `@Verfiyica.Order` annotation are ordered before test methods with `@Verfiyica.Order`
+- Test methods without an `@Verfiyica.Order` annotation are ordered before test methods without `@Verfiyica.Order` annotation
 
 ---
 
@@ -239,7 +239,7 @@ Used by Verifyica to order test classes / test methods.
 - If `verifyica.engine.class.parallelism` is greater than `1`, orders test class **execution submission order**.
   - Test class execution will still be in parallel.
 
-- Method that are ordered using `@Verifyica.Orderr` are executed before methods that are not annotated. 
+- Test methods without an `@Verfiyica.Order` annotation are ordered before test methods without `@Verfiyica.Order` annotation 
 
 ---
 

--- a/ANNOTATIONS.md
+++ b/ANNOTATIONS.md
@@ -213,7 +213,7 @@ All methods annotated with `@Verifyica.Test`:
 
 - Default ordering is by test method name (or `@verifyica.DisplayName` if used)
 
-- Test methods without an `@Verfiyica.Order` annotation are ordered before test methods without `@Verfiyica.Order` annotation
+- Test methods with an `@Verfiyica.Order` annotation are ordered before test methods without an `@Verfiyica.Order` annotation
 
 ---
 
@@ -239,7 +239,7 @@ Used by Verifyica to order test classes / test methods.
 - If `verifyica.engine.class.parallelism` is greater than `1`, orders test class **execution submission order**.
   - Test class execution will still be in parallel.
 
-- Test methods without an `@Verfiyica.Order` annotation are ordered before test methods without `@Verfiyica.Order` annotation 
+- Test methods with an `@Verfiyica.Order` annotation are ordered before test methods without an `@Verfiyica.Order` annotation 
 
 ---
 

--- a/ANNOTATIONS.md
+++ b/ANNOTATIONS.md
@@ -213,7 +213,7 @@ All methods annotated with `@Verifyica.Test`:
 
 - Default ordering is by test method name (or `@verifyica.DisplayName` if used)
 
-- Test methods with an `@Verfiyica.Order` annotation are ordered before test methods without an `@Verfiyica.Order` annotation
+- Test methods with an `@Verifyica.Order` annotation are ordered before test methods without an `@Verifyica.Order` annotation
 
 ---
 
@@ -239,7 +239,7 @@ Used by Verifyica to order test classes / test methods.
 - If `verifyica.engine.class.parallelism` is greater than `1`, orders test class **execution submission order**.
   - Test class execution will still be in parallel.
 
-- Test methods with an `@Verfiyica.Order` annotation are ordered before test methods without an `@Verfiyica.Order` annotation 
+- Test methods with an `@Verifyica.Order` annotation are ordered before test methods without an `@Verifyica.Order` annotation 
 
 ---
 

--- a/ANNOTATIONS.md
+++ b/ANNOTATIONS.md
@@ -239,6 +239,8 @@ Used by Verifyica to order test classes / test methods.
 - If `verifyica.engine.class.parallelism` is greater than `1`, orders test class **execution submission order**.
   - Test class execution will still be in parallel.
 
+- Method that are ordered using `@Verifyica.Orderr` are executed before methods that are not annotated. 
+
 ---
 
 ### @Verifyica.DisplayName

--- a/engine/src/main/java/org/verifyica/engine/support/OrderSupport.java
+++ b/engine/src/main/java/org/verifyica/engine/support/OrderSupport.java
@@ -75,8 +75,16 @@ public class OrderSupport {
             Verifyica.Order o1 = m1.getAnnotation(Verifyica.Order.class);
             Verifyica.Order o2 = m2.getAnnotation(Verifyica.Order.class);
 
-            int orderValue1 = (o1 != null) ? o1.value() : 0;
-            int orderValue2 = (o2 != null) ? o2.value() : 0;
+            if (o1 == null && o2 == null) {
+                return 0;
+            } else if (o1 == null) {
+                return 1;
+            } else if (o2 == null) {
+                return -1;
+            }
+
+            int orderValue1 = o1.value();
+            int orderValue2 = o2.value();
 
             if (orderValue1 == 0 && orderValue2 == 0) {
                 return 0;

--- a/tests/src/test/java/org/verifyica/test/LifecycleTest1.java
+++ b/tests/src/test/java/org/verifyica/test/LifecycleTest1.java
@@ -85,6 +85,13 @@ public class LifecycleTest1 implements AutoCloseable {
     }
 
     @Verifyica.Test
+    public void test0(ArgumentContext argumentContext) throws Throwable {
+        System.out.printf("  %s test0()%n", argumentContext.getTestArgument().getPayload());
+
+        actual.add("test0");
+    }
+
+    @Verifyica.Test
     @Verifyica.Order(0)
     public void test1(ArgumentContext argumentContext) throws Throwable {
         System.out.printf("  %s test1()%n", argumentContext.getTestArgument().getPayload());
@@ -172,6 +179,16 @@ public class LifecycleTest1 implements AutoCloseable {
                 expected.add(state);
                 expected.add("post" + capitalize(state));
             }
+
+            expected.add("preBeforeEach");
+            expected.add("beforeEach");
+            expected.add("postBeforeEach");
+            expected.add("preTest");
+            expected.add("test0");
+            expected.add("postTest");
+            expected.add("preAfterEach");
+            expected.add("afterEach");
+            expected.add("postAfterEach");
 
             state = "afterAll";
             expected.add("pre" + capitalize(state));

--- a/tests/src/test/java/org/verifyica/test/order/OrderTest1.java
+++ b/tests/src/test/java/org/verifyica/test/order/OrderTest1.java
@@ -73,8 +73,8 @@ public class OrderTest1 implements AutoCloseable {
         List<String> expected = new ArrayList<>();
         expected.add("test2");
         expected.add("test3");
-        expected.add("test4");
         expected.add("test1");
+        expected.add("test4");
 
         assertThat(actual.size()).isEqualTo(expected.size());
 


### PR DESCRIPTION
Fix ordering semantics so that test methods with an `@Verifyica.Order` annotation are ordered before test methods without an `@Verifyica.Order` annotation