### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/verifyica-team/verifyica/security/code-scanning/2](https://github.com/verifyica-team/verifyica/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the current workflow since it only checks out the repository and runs a build. This change ensures that the workflow adheres to the principle of least privilege by explicitly limiting the permissions of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
