### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -1,5 +1,7 @@
 name: Manual Build
 on: [workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/verifyica-team/verifyica/security/code-scanning/1](https://github.com/verifyica-team/verifyica/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents to perform the build, we will set `contents: read` as the minimal required permission. This ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
